### PR TITLE
Fix name logo stuck out of place after hover

### DIFF
--- a/src/components/AmnishLogo.tsx
+++ b/src/components/AmnishLogo.tsx
@@ -13,6 +13,7 @@ const AmnishLogo = () => {
                 title="Lightning Amnish"
             >
                 <motion.img
+                    animate={{ x: 0 }}
                     whileHover={{ scale: 1.125, x: [-5, 5, -5, 5, 0] }}
                     transition={{ duration: 0.1, type: "just" }}
                     className="w-14 rounded-full"


### PR DESCRIPTION
The logo is no longer stuck in a weird position after quick hovers.

This PR adds a default animation of `translateX` value set to `0`, that pulls it back to original position no matter how long the hover was.

![AmnishLogoFix](https://github.com/Amnish04/amnish-web-portfolio/assets/78865303/50dd5ccf-4c43-4dc1-a221-7b5734cd89c5)

This fixes #4 
